### PR TITLE
Refactor Monitorer to improve result handling and readability

### DIFF
--- a/internal/monitorer/monitorer_test.go
+++ b/internal/monitorer/monitorer_test.go
@@ -20,7 +20,7 @@ func mockOption(ctrl *gomock.Controller) *mock.MockOption {
 	return mo
 }
 
-func TestMonitorer_result(t *testing.T) {
+func TestMonitorer_fetchResult(t *testing.T) {
 	tests := []struct {
 		name           string
 		mockHTTPClient func(ctrl *gomock.Controller) *mock.MockHTTPClient
@@ -55,7 +55,7 @@ func TestMonitorer_result(t *testing.T) {
 
 			m := New(mc, nil, nil, targetURL, opt)
 
-			got, err := m.result(context.Background())
+			got, err := m.fetchResult(context.Background())
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
- Introduced `once` and `handleResult` methods to simplify the main loop logic.
- Renamed `result` to `fetchResult` for better clarity.
- Updated related test functions to align with the new method name.